### PR TITLE
Add new CSV output option for the check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the working area for the IETF SACM Information Model draft.
 * [Editor's copy](http://sacmwg.github.io/draft-ietf-sacm-information-model/)
 * [Working Group Draft] (https://tools.ietf.org/html/draft-ietf-sacm-information-model)
 * [Compare Working Group and Editor's Drafts] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-ietf-sacm-information-model&url2=https://sacmwg.github.io/draft-ietf-sacm-information-model/draft-ietf-sacm-information-model.txt)
-* [HTML View derived from Editor's copy] (https://sacmwg.github.io/draft-ietf-smime-information-model/im.html)
+* [HTML View derived from Editor's copy] (https://sacmwg.github.io/draft-ietf-sacm-information-model/im.html)
 
 ## Document Status
 

--- a/css/style.css
+++ b/css/style.css
@@ -14,7 +14,7 @@ table.tablesorter thead tr th, table.tablesorter tfoot tr th {
 	padding: 4px;
 }
 table.tablesorter thead tr .header {
-	background-image: url(bg.gif);
+	background-image: url("https://github.com/sacmwg/draft-ietf-sacm-information-model/blob/master/css/bg.gif");
 	background-repeat: no-repeat;
 	background-position: center right;
 	cursor: pointer;
@@ -29,10 +29,10 @@ table.tablesorter tbody tr.odd td {
 	background-color:#F0F0F6;
 }
 table.tablesorter thead tr .headerSortUp {
-	background-image: url(asc.gif);
+	background-image: url("https://github.com/sacmwg/draft-ietf-sacm-information-model/blob/master/css/asc.gif");
 }
 table.tablesorter thead tr .headerSortDown {
-	background-image: url(desc.gif);
+	background-image: url("https://github.com/sacmwg/draft-ietf-sacm-information-model/blob/master/css/desc.gif");
 }
 table.tablesorter thead tr .headerSortDown, table.tablesorter thead tr .headerSortUp {
 background-color: #8dbdd8;


### PR DESCRIPTION
Check now has an --csv option for doing outputs
CRLF breaks are replaced by || inside of descriptions to make life easier for people using real editors

Point to the correct gif files from the CSS for the html version of the IM elements
Correct the link to the IM table
